### PR TITLE
Aid in building behind a firewall

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -19,7 +19,8 @@ RUN apt-get update && apt-get install -y curl && curl -sL https://deb.nodesource
 
 
 # Install Lemur
-RUN cd /usr/local/src &&\
+RUN git config --global url."https://".insteadOf git:// &&\
+  cd /usr/local/src &&\
   git clone --depth 1 -b 0.1.3 --branch master https://github.com/netflix/lemur.git &&\
   cd lemur &&\
   python setup.py develop


### PR DESCRIPTION
At some point in the docker build process git repositories are fetched
using git:// by default which may be blocked by company firewalls.

The simple fix is to configure git to use https:// in these instances.