### PR TITLE
Upgrade to 0.4.0

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -24,8 +24,12 @@ RUN git config --global url."https://".insteadOf git:// &&\
   git clone https://github.com/netflix/lemur.git &&\
   cd lemur &&\
   git fetch &&\
-  git checkout 0.3.0 &&\
-  python setup.py develop
+  pip install --upgrade virtualenv &&\
+  virtualenv venv &&\
+  export PATH=/usr/local/src/lemur/venv/bin:${PATH} &&\
+  pip install --upgrade pip virtualenv &&\
+  git checkout 0.4.0 &&\
+  make develop
 
 # Create static files
 RUN cd /usr/local/src/lemur && npm install --unsafe-perm && node_modules/.bin/gulp build && node_modules/.bin/gulp package && rm -r bower_components node_modules

--- a/web/api-start.sh
+++ b/web/api-start.sh
@@ -37,5 +37,8 @@ echo "Done changing postgres password..."
 echo "DONE CREATING lemurdb..."
 
 cd /usr/local/src/lemur/lemur
+
+export PATH=/usr/local/src/lemur/venv/bin:${PATH}
+
 python manage.py init -p password
 python manage.py start -w 6 -b 0.0.0.0:8000

--- a/web/api-start.sh
+++ b/web/api-start.sh
@@ -1,5 +1,32 @@
 #!/bin/bash
 
+# sleep for $SLEEP seconds to a maxium of 10 tries
+SLEEP=1
+
+db_not_ready() {
+    echo ERROR: failed to connect to db
+    echo " "
+    echo "postgresql server was not initialised in time or correctly. Try running 'docker-compose up' again."
+    echo If the problem persists, consider inspecting the postgresql container for logs or waiting longer for
+    echo DB to initialise by increasing the SLEEP var in web/api-start.sh to a higher value and rebuilding
+    echo the containers
+    echo " "
+    exit 1
+}
+
+wait_db() {
+    for i in $(seq 1 10); do
+        echo -e "\033[1mAttempt to connect to db.. try #$i\033[0m"
+        sudo -u postgres psql -h postgres --command 'select 1;' && return 0
+        sleep $SLEEP
+    done
+    return 1
+}
+echo "Waiting for db to become available"
+wait_db
+[ "x$?" == "x0" ] && printf "db ready!\n\n" || db_not_ready
+
+
 echo "Creating lemurdb..."
 sudo -u postgres psql -h postgres --command "CREATE DATABASE lemur;"
 echo "Creating the lemur user..."


### PR DESCRIPTION
Had to upgrade to 0.4.0 to try it out, figured I 'd send it through. 

#### Changes
* Add wait/retry logic for postgres because running docker-compose up sometimes fails to initialise the database properly 
* Use virtualenv (modifies PATH)

Regarding first point, it will not exit on failure - maybe you want the retry timeout increased and exit with a more graceful message? I didn't want to change the behaviour too much. 

If you want me to split this to separate PRs I can do that too. 