### PR TITLE
Install pip for python 3.5, fix trailing && error

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -17,18 +17,20 @@ MAINTAINER Netflix Open Source Development <talent@netflix.com>
 
 RUN apt-get update && \
   apt-get -y install software-properties-common && \
-  add-apt-repository -y ppa:jonathonf/python-3.5 
+  add-apt-repository -y ppa:jonathonf/python-3.5
 
 RUN apt-get update && \
-  apt-get install -y curl python3.5-dev python3-pip git sudo libpq-dev libffi-dev \
-    python3-psycopg2 postgresql-client-9.3 postgresql-contrib-9.3 postgresql-9.3 && \
-  update-alternatives --install /usr/bin/python python /usr/bin/python3.5 1 && \
+  apt-get install -y curl python3.5-dev git sudo libpq-dev libffi-dev \
+    python3-psycopg2 postgresql-client-9.3 postgresql-contrib-9.3 && \
+  update-alternatives --install /usr/bin/python python /usr/bin/python3.5 1
+
+RUN curl -s https://bootstrap.pypa.io/get-pip.py | python
 
 RUN curl -sL https://deb.nodesource.com/setup_4.x | bash - && \
-  apt-get -y install nodejs && \
-  update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
+  apt-get -y install nodejs make && \
+  update-alternatives --install /usr/bin/pip pip /usr/local/bin/pip 1
 
-RUN locale-gen en_US.UTF-8 
+RUN locale-gen en_US.UTF-8
 
 ENV LC_ALL=en_US.UTF-8
 
@@ -49,7 +51,7 @@ RUN git config --global url."https://".insteadOf git:// &&\
 # Create static files
 RUN cd /usr/local/src/lemur && npm install --unsafe-perm && node_modules/.bin/gulp build && node_modules/.bin/gulp package && rm -r bower_components node_modules
 
-ADD lemur.conf.py /usr/local/src/lemur/lemur.conf.py 
+ADD lemur.conf.py /usr/local/src/lemur/lemur.conf.py
 ADD api-start.sh /usr/local/src/lemur/scripts/api-start.sh
 RUN chmod +x /usr/local/src/lemur/scripts/api-start.sh
 


### PR DESCRIPTION
This fixes a couple issues found in #15. 

This time we ensure that pip is installed for python 3.5. Current version installs pip only for python 3.4. 

I see two other open pull requests that add npm install. This actually shouldn't be necessary because npm is installed along with nodejs v4. But there was an error in the previous PR. Line 25 had a trailing `&& \` causing the subsequent `RUN` to fail, so nodejs and hence npm was not installed. 


