### PR TITLE
Fix errors and upgrade to ubuntu:18.04

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -12,15 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 LABEL maintainer="Netflix Open Source Development <talent@netflix.com>"
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
   apt-get install -y curl git build-essential sudo \
     python3 python3-pip python3-dev \
     nodejs npm \
     postgresql postgresql-contrib \
-    libpq-dev libssl-dev libffi-dev libsasl2-dev libldap2-dev && \
+    libpq-dev libffi-dev libsasl2-dev libldap2-dev && \
   update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
   update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1 && \
   update-alternatives --install /usr/bin/node node /usr/bin/nodejs 1 && \

--- a/web/api-start.sh
+++ b/web/api-start.sh
@@ -30,7 +30,7 @@ wait_db
 echo "Creating lemurdb..."
 sudo -u postgres psql -h postgres --command "CREATE DATABASE lemur;"
 echo "Creating the lemur user..."
-sudo -u postgres psql -h postgres --command "CREATE USER lemur WITH PASSWORD 'lemur';"
+sudo -u postgres psql -h postgres --command "CREATE USER lemur WITH SUPERUSER PASSWORD 'lemur';"
 echo "Changing postgres password..."
 sudo -u postgres psql -h postgres --command "GRANT ALL PRIVILEGES ON DATABASE lemur to lemur;"
 echo "Done changing postgres password..."


### PR DESCRIPTION
I was getting the following error when building `lemur-web`:
```
Collecting black==19.3b0 (from lemur[tests])
  ERROR: Could not find a version that satisfies the requirement black==19.3b0 (from lemur[tests]) (from versions: none)
ERROR: No matching distribution found for black==19.3b0 (from lemur[tests])
make: *** [develop] Error 1
Makefile:7: recipe for target 'develop' failed
ERROR: Service 'lemur-web' failed to build: The command '/bin/sh -c git config --global url."https://".insteadOf git:// &&  cd /usr/local/src &&  git clone https://github.com/netflix/lemur.git &&  cd lemur &&  git checkout ${LEMUR_VERSION} &&  pip install --upgrade pip virtualenv &&  export PATH=/usr/local/src/lemur/venv/bin:${PATH} &&  virtualenv -p python3 venv &&  . venv/bin/activate &&  make ${LEMUR_TARGET}' returned a non-zero code: 2
```
This seemed to be related to the inclusion of the `libssl-dev` package in the `apt` command.  Then there was an issue with ubuntu:16.04 packaging python3.5, which doesn't work since lemur uses f-strings.  Thus I updated Ubuntu to 18.04.  Finally, there was a problem involving postgres permissions to create the pg_trgm extension, preventing the user table from being created.  Thus I made the postgres user a superuser.

Those were all of the changes I made, and now it works for me.