### PR TITLE
Resolves npm dependency issue and libssl-dev issue

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -22,9 +22,10 @@ add-apt-repository ppa:deadsnakes/ppa -y && \
   apt-get update && \
   apt-get install -y curl git build-essential sudo \
     python3.6 python3-pip python3.6-dev \
-    nodejs npm \
-    postgresql postgresql-contrib \
-    libpq-dev libssl-dev libffi-dev libsasl2-dev libldap2-dev && \
+    nodejs-dev && \
+    apt-get install -y npm && \
+    apt-get install -y postgresql postgresql-contrib \
+    libpq-dev libffi-dev libsasl2-dev libldap2-dev && \
   ln -sf /usr/bin/python3.6 /usr/local/bin/python3 && \
   update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
   update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1 && \


### PR DESCRIPTION
Encompasses #43 and the unaddressed second cause of #41 

If npm is not installed on its own, it throws error "The following packages have unmet dependencies: npm : Depends: node-gyp (>= 0.10.9) but it is not going to be installed"

libssl-dev no longer defaults to 1.0, and throws error:
"The following packages have unmet dependencies:
 libssl-dev : Conflicts: libssl1.0-dev but 1.0.2n-1ubuntu5.3 is to be installed
 libssl1.0-dev : Conflicts: libssl-dev but 1.1.1-1ubuntu2.1~18.04.5 is to be installed"
libssl1.0-dev is already installed as a prior dependency, and does not need to be reinstalled.

