### PR TITLE
Fix HEALTHCHECK of lemur container

### DIFF
--- a/lemur-build-docker/Dockerfile
+++ b/lemur-build-docker/Dockerfile
@@ -71,7 +71,7 @@ RUN chmod +x /entrypoint
 WORKDIR /
 
 HEALTHCHECK --interval=12s --timeout=12s --start-period=30s \
- CMD curl --fail http://localhost:80/api/1/healthcheck | grep -q ok || exit 1
+ CMD curl --fail http://localhost:8000/api/1/healthcheck | grep -q ok || exit 1
 
 USER root
 


### PR DESCRIPTION
The lemur service listens on port :8000 inside the container, not :80. The
Docker HEALTHCHECK runs inside the container, failed, and the container was
marked unhealthy.

```shell
$ docker inspect lemur-docker_lemur_1 | jq .[0].State.Health
{
  "Status": "unhealthy",
  "FailingStreak": 69,
  "Log": [
    {
      "Start": "2021-07-29T18:00:17.2834705Z",
      "End": "2021-07-29T18:00:17.3647431Z",
      "ExitCode": 1,
      "Output": "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\ncurl: (7) Failed to connect to localhost port 80: Connection refused\n"
    },
```

Fixes #62