### PR TITLE
Typo in container name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - 447:443
 
   lemur:
-    image: netlix-lemur:latest
+    image: netflix-lemur:latest
     build:
       context: ./lemur-build-docker
     #container_name: lemur


### PR DESCRIPTION
The container built for the lemur runtime was called `netlix-lemur` instead of `netflix-lemur`. This typo was bothering me. It has no real impact, but I kept typing it wrong when I wasn't using tab-completion. 