### PR TITLE
fix: Update base image to Ubuntu 22.04 and solve Docker build failure 

### DIFF
--- a/lemur-build-docker/Dockerfile
+++ b/lemur-build-docker/Dockerfile
@@ -1,5 +1,5 @@
 #############  BUILDER  #############
-FROM ubuntu:20.04 as builder
+FROM ubuntu:22.04 as builder
 LABEL maintainer="Netflix Open Source Development <talent@netflix.com>"
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -12,8 +12,13 @@ WORKDIR /opt/lemur
 
 RUN apt-get update && \
     apt-get -y --no-install-recommends upgrade && \
-    apt-get install -y --no-install-recommends libpq-dev curl build-essential locales libffi-dev libsasl2-dev libldap2-dev \
-        dh-autoreconf git python3-dev python3-pip python3-venv python3-wheel nodejs npm && \
+    apt-get install -y --no-install-recommends curl ca-certificates gnupg && \
+    mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends libpq-dev build-essential locales libffi-dev libsasl2-dev libldap2-dev \
+        dh-autoreconf git python3-dev python3-pip python3-venv python3-wheel nodejs && \
     locale-gen en_US.UTF-8 && export LC_ALL=en_US.UTF-8 && \
     npm config set registry https://registry.npmjs.org/ && \
     npm install npm -g && \
@@ -30,7 +35,7 @@ RUN apt-get update && \
     python3 -c 'print(" \033[32m BUILDER DONE \033[0m ")'
 
 #############  APP  #############
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 LABEL maintainer="Netflix Open Source Development <talent@netflix.com>"
 
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
This pull request updates the Docker build process for the project to use Ubuntu 22.04 instead of 20.04, and modernizes the installation of Node.js and related dependencies. These changes ensure better compatibility with recent software and security updates.

**Base image and dependency updates:**

* Changed the base image in both the builder and app stages of the `Dockerfile` from `ubuntu:20.04` to `ubuntu:22.04`, ensuring the use of a more recent and supported operating system. [[1]](diffhunk://#diff-fdbf262700ced7ce11726911b6e8501abc9b95d9f741d229ef75ed8ad04db11dL2-R2) [[2]](diffhunk://#diff-fdbf262700ced7ce11726911b6e8501abc9b95d9f741d229ef75ed8ad04db11dL33-R38)

**Node.js installation improvements:**

* Replaced the default Node.js and npm installation with a process that adds the official NodeSource repository for Node.js 20.x, ensuring the use of a current Node.js version and more secure package verification.

**Dependency management:**

* Updated the list of installed packages to remove redundant or unnecessary packages and to streamline the installation process, improving build reliability and reducing image size.* 
```
213.1 Setting up node-uuid (3.3.2-2) ...
213.1 Setting up node-from2 (2.3.0-1) ...
213.1 Setting up node-extend (3.0.2-1) ...
213.1 Setting up node-jsonstream (1.3.5-1) ...
213.1 Setting up node-lazy-property (1.0.0-3) ...
213.1 Setting up libheimntlm0-heimdal:arm64 (7.7.0+dfsg-1ubuntu1.4) ...
213.1 Setting up node-yargs-parser (18.1.1-1) ...
213.1 Setting up gcc (4:9.3.0-1ubuntu2) ...
213.1 Setting up node-dashdash (1.14.1-2) ...
213.1 Setting up dpkg-dev (1.19.7ubuntu3.2) ...
213.1 Setting up intltool-debian (0.35.0+20060710.5) ...
213.1 Setting up node-make-dir (3.0.2-1) ...
213.1 Setting up node-validate-npm-package-name (3.0.0-1) ...
213.1 Setting up node-promzard (0.3.0-1) ...
213.1 Setting up liberror-perl (0.17029-1) ...
213.1 Setting up node-wcwidth.js (1.0.0-1) ...
213.1 Setting up node-locate-path (5.0.0-2) ...
213.2 Setting up node-ecc-jsbn (0.2.0-2) ...
213.2 Setting up node-combined-stream (1.0.8-1) ...
213.2 Setting up node-unique-filename (1.1.1+ds-1) ...
213.2 Setting up libgssapi3-heimdal:arm64 (7.7.0+dfsg-1ubuntu1.4) ...
213.2 Setting up libpython3.8-dev:arm64 (3.8.10-0ubuntu1~20.04.18) ...
213.2 Setting up node-brace-expansion (1.1.11-1) ...
213.2 Setting up python3.8-venv (3.8.10-0ubuntu1~20.04.18) ...
213.2 Setting up node-form-data (3.0.0-2) ...
213.2 Setting up node-strip-ansi (6.0.0-2) ...
213.2 Setting up node-lockfile (1.0.4-3) ...
213.2 Setting up node-spdx-expression-parse (3.0.0-1) ...
213.2 Setting up node-parallel-transform (1.1.0-2) ...
213.2 Setting up node-which (2.0.2-1) ...
213.2 Setting up python3-pip (20.0.2-5ubuntu1.11) ...
213.3 Setting up g++-9 (9.4.0-1ubuntu1~20.04.2) ...
213.3 Setting up node-lcid (1.0.0-1) ...
213.3 Setting up node-typedarray-to-buffer (3.0.3-3) ...
213.3 Setting up python3.8-dev (3.8.10-0ubuntu1~20.04.18) ...
213.3 Setting up node-dot-prop (5.2.0-1) ...
213.3 Setting up g++ (4:9.3.0-1ubuntu2) ...
213.3 update-alternatives: using /usr/bin/g++ to provide /usr/bin/c++ (c++) in auto mode
213.3 update-alternatives: warning: skip creation of /usr/share/man/man1/c++.1.gz because associated file /usr/share/man/man1/g++.1.gz (of link group c++) doesn't exist
213.3 Setting up node-stream-iterate (1.2.0-4) ...
213.3 Setting up node-tar (4.4.10+ds1-2ubuntu1) ...
213.3 Setting up node-inflight (1.0.6-1) ...
213.3 Setting up node-has-to-string-tag-x (1.4.1+dfsg-1) ...
213.3 Setting up node-tough-cookie (3.0.0-1) ...
213.3 Setting up node-rc (1.2.8-1) ...
213.3 Setting up build-essential (12.8ubuntu1.1) ...
213.3 Setting up node-is-path-inside (1.0.1-1) ...
213.3 Setting up node-minimatch (3.0.4-4ubuntu0.1) ...
213.3 Setting up node-npm-package-arg (6.1.1-1) ...
213.3 Setting up node-verror (1.10.0-1) ...
213.3 Setting up node-getpass (0.1.7-1) ...
213.3 Setting up node-nopt (3.0.6-4) ...
213.3 Setting up node-isurl (4.0.1-2) ...
213.3 Setting up node-color-convert (1.9.3-1) ...
213.3 Setting up node-string-width (2.1.1-1) ...
213.3 Setting up gyp (0.1+20180428git4d467626-3ubuntu1) ...
213.5 Setting up libfile-stripnondeterminism-perl (1.7.0-1) ...
213.5 Setting up node-har-validator (5.1.3-1) ...
213.5 Setting up node-readable-stream (3.4.0-2) ...
213.5 Setting up node-ssri (7.1.0-2) ...
213.5 Setting up node-through2 (3.0.1-2) ...
213.5 Setting up node-lru-cache (5.1.1-5) ...
213.5 Setting up node-bcrypt-pbkdf (1.0.2-1) ...
213.5 Setting up node-promise-retry (1.1.1-4) ...
213.5 Setting up libpython3-dev:arm64 (3.8.2-0ubuntu2) ...
213.5 Setting up node-end-of-stream (1.4.4-1) ...
213.5 Setting up node-pump (3.0.0-2) ...
213.5 Setting up node-write-file-atomic (3.0.3-1) ...
213.5 Setting up node-columnify (1.5.4-1) ...
213.5 Setting up node-jsprim (1.4.1-1) ...
213.5 Setting up node-flush-write-stream (2.0.0-2) ...
213.5 Setting up po-debconf (1.0.21) ...
213.5 Setting up node-are-we-there-yet (1.1.5-1) ...
213.5 Setting up node-find-up (4.1.0-2) ...
213.5 Setting up libldap-2.4-2:arm64 (2.4.49+dfsg-2ubuntu1.10) ...
213.6 Setting up libcurl3-gnutls:arm64 (7.68.0-1ubuntu2.25) ...
213.6 Setting up libldap2-dev:arm64 (2.4.49+dfsg-2ubuntu1.10) ...
213.6 Setting up node-duplexify (4.1.1-1) ...
213.6 Setting up node-spdx-correct (3.1.0-1) ...
213.6 Setting up node-cross-spawn (5.1.0-2) ...
213.6 Setting up python3-venv (3.8.2-0ubuntu2) ...
213.6 Setting up node-ansi-styles (4.2.1-1) ...
213.6 Setting up node-glob (7.1.6-1) ...
213.6 Setting up python3-dev (3.8.2-0ubuntu2) ...
213.6 Setting up node-get-stream (4.1.0-1) ...
213.6 Setting up node-pumpify (2.0.1-1) ...
213.6 Setting up node-widest-line (3.1.0-1) ...
213.6 Setting up node-got (7.1.0-1) ...
213.6 Setting up node-chalk (2.4.2-1) ...
213.6 Setting up git (1:2.25.1-1ubuntu3.14) ...
213.6 Setting up node-configstore (5.0.1-1) ...
213.6 Setting up node-registry-url (3.1.0-1) ...
213.6 Setting up dh-strip-nondeterminism (1.7.0-1) ...
213.6 Setting up node-registry-auth-token (3.3.1-1) ...
213.6 Setting up libcurl4:arm64 (7.68.0-1ubuntu2.25) ...
213.6 Setting up node-wide-align (1.1.3-1) ...
213.6 Setting up curl (7.68.0-1ubuntu2.25) ...
213.6 Setting up node-ansi-align (3.0.0-1) ...
213.6 Setting up node-rimraf (2.6.3-1) ...
213.6 Setting up node-sshpk (1.16.1+dfsg-2) ...
213.6 Setting up node-bl (4.0.0-2) ...
213.6 Setting up node-validate-npm-package-license (3.0.4-1) ...
213.6 Setting up node-stream-each (1.2.3-1) ...
213.6 Setting up node-mississippi (3.0.0-1) ...
213.6 Setting up node-execa (0.10.0+dfsg-1) ...
213.6 Setting up node-copy-concurrently (1.0.5-4) ...
213.6 Setting up libpq5:arm64 (12.22-0ubuntu0.20.04.4) ...
213.6 Setting up node-move-concurrently (1.0.1-2) ...
213.6 Setting up libpq-dev (12.22-0ubuntu0.20.04.4) ...
213.6 Setting up node-term-size (1.2.0+dfsg-2) ...
213.6 Setting up node-os-locale (4.0.0-1) ...
213.6 Setting up node-http-signature (1.3.2-1) ...
213.7 Setting up node-fs-vacuum (1.2.10-3) ...
213.7 Setting up node-gauge (2.7.4-1) ...
213.7 Setting up node-wrap-ansi (4.0.0-2) ...
213.7 Setting up node-normalize-package-data (2.5.0-1) ...
213.7 Setting up node-boxen (4.2.0-2) ...
213.7 Setting up node-package-json (4.0.1-1) ...
213.7 Setting up node-latest-version (3.1.0-1) ...
213.7 Setting up node-request (2.88.1-4) ...
213.7 Setting up node-npmlog (4.1.2-2) ...
213.7 Setting up node-cliui (4.1.0-2) ...
213.7 Setting up node-yargs (15.3.0-1) ...
213.7 Setting up node-cacache (11.3.3-2) ...
213.7 Setting up node-read-package-json (2.1.1-1) ...
213.7 Setting up node-gyp (6.1.0-3) ...
213.7 Setting up node-libnpx (10.2.1-2) ...
213.7 Setting up npm (6.14.4+ds-1ubuntu2) ...
213.7 Setting up dh-autoreconf (19) ...
213.7 Setting up debhelper (12.10ubuntu1) ...
213.7 Processing triggers for libc-bin (2.31-0ubuntu9.18) ...
213.7 Processing triggers for ca-certificates (20240203~20.04.1) ...
213.7 Updating certificates in /etc/ssl/certs...
213.8 0 added, 0 removed; done.
213.8 Running hooks in /etc/ca-certificates/update.d...
213.8 done.
213.8 Generating locales (this might take a while)...
213.8   en_US.UTF-8... done
214.3 Generation complete.
217.6 /usr/local/bin/npx -> /usr/local/lib/node_modules/npm/bin/npx-cli.js
217.6 /usr/local/bin/npm -> /usr/local/lib/node_modules/npm/bin/npm-cli.js
217.7 npm WARN notsup Unsupported engine for npm@11.8.0: wanted: {"node":"^20.17.0 || >=22.9.0"} (current: {"node":"10.19.0","npm":"6.14.4"})
217.7 npm WARN notsup Not compatible with your version of node/npm: npm@11.8.0
217.7 
217.7 + npm@11.8.0
217.7 added 162 packages from 73 contributors in 2.934s
217.7 Running with nodejs:
217.7 v10.19.0
218.2 Running with python:
218.2 3.8.10
218.7 Collecting pip
219.1   Downloading pip-25.0.1-py3-none-any.whl (1.8 MB)
223.7 Collecting setuptools
223.8   Downloading setuptools-75.3.3-py3-none-any.whl (1.3 MB)
227.4 Collecting wheel
227.4   Downloading wheel-0.45.1-py3-none-any.whl (72 kB)
227.7 Installing collected packages: pip, setuptools, wheel
227.7   Attempting uninstall: pip
227.7     Found existing installation: pip 20.0.2
227.7     Uninstalling pip-20.0.2:
227.7       Successfully uninstalled pip-20.0.2
227.9   Attempting uninstall: setuptools
227.9     Found existing installation: setuptools 44.0.0
227.9     Uninstalling setuptools-44.0.0:
227.9       Successfully uninstalled setuptools-44.0.0
228.2 Successfully installed pip-25.0.1 setuptools-75.3.3 wheel-0.45.1
228.3 Obtaining file:///opt/lemur
228.3   Installing build dependencies: started
229.7   Installing build dependencies: finished with status 'done'
229.7   Checking if build backend supports build_editable: started
229.8   Checking if build backend supports build_editable: finished with status 'done'
229.8   Getting requirements to build editable: started
229.9   Getting requirements to build editable: finished with status 'done'
229.9   Preparing editable metadata (pyproject.toml): started
230.1   Preparing editable metadata (pyproject.toml): finished with status 'done'
230.3 INFO: pip is looking at multiple versions of lemur to determine which version is compatible with other requirements. This could take a while.
230.3 ERROR: Could not find a version that satisfies the requirement acme==3.3.0 (from lemur) (from versions: 0.0.0.dev20151006, 0.0.0.dev20151008, 0.0.0.dev20151017, 0.0.0.dev20151020, 0.0.0.dev20151021, 0.0.0.dev20151024, 0.0.0.dev20151030, 0.0.0.dev20151104, 0.0.0.dev20151107, 0.0.0.dev20151108, 0.0.0.dev20151114, 0.0.0.dev20151123, 0.0.0.dev20151201, 0.1.0, 0.1.1, 0.2.0, 0.3.0, 0.4.0, 0.4.1, 0.4.2, 0.5.0, 0.6.0, 0.7.0, 0.8.0, 0.8.1, 0.9.0, 0.9.1, 0.9.2, 0.9.3, 0.10.0, 0.10.1, 0.10.2, 0.11.0, 0.11.1, 0.12.0, 0.13.0, 0.14.0, 0.14.1, 0.14.2, 0.15.0, 0.16.0, 0.17.0, 0.18.0, 0.18.1, 0.18.2, 0.19.0, 0.20.0, 0.21.0, 0.21.1, 0.22.0, 0.22.1, 0.22.2, 0.23.0, 0.24.0, 0.25.0, 0.25.1, 0.26.0, 0.26.1, 0.27.0, 0.27.1, 0.28.0, 0.29.0, 0.29.1, 0.30.0, 0.30.1, 0.30.2, 0.31.0, 0.32.0, 0.33.0, 0.33.1, 0.34.0, 0.34.1, 0.34.2, 0.35.0, 0.35.1, 0.36.0, 0.37.0, 0.37.1, 0.37.2, 0.38.0, 0.39.0, 0.40.0, 0.40.1, 1.0.0, 1.1.0, 1.2.0, 1.3.0, 1.4.0, 1.5.0, 1.6.0, 1.7.0, 1.8.0, 1.9.0, 1.10.0, 1.10.1, 1.11.0, 1.12.0, 1.13.0, 1.14.0, 1.15.0, 1.16.0, 1.17.0, 1.18.0, 1.19.0, 1.20.0, 1.21.0, 1.22.0, 1.23.0, 1.24.0, 1.25.0, 1.26.0, 1.27.0, 1.28.0, 1.29.0, 1.30.0, 1.31.0, 1.32.0, 2.0.0, 2.1.0, 2.2.0, 2.3.0, 2.4.0, 2.5.0, 2.6.0, 2.7.0, 2.7.1, 2.7.2, 2.7.3, 2.7.4, 2.8.0, 2.9.0, 2.10.0, 2.11.0, 2.11.1, 3.0.0, 3.0.1)
[+] up 0/2R: No matching distribution found for acme==3.3.0
 ⠹ Image netflix-lemur:latest Building                                                                                         233.8s 
 ⠙ Image lemur-docker-nginx   Building                                                                                         231.5s 
Dockerfile:13

--------------------

  12 |     

  13 | >>> RUN apt-get update && \

  14 | >>>     apt-get -y --no-install-recommends upgrade && \

  15 | >>>     apt-get install -y --no-install-recommends libpq-dev curl build-essential locales libffi-dev libsasl2-dev libldap2-dev \

  16 | >>>         dh-autoreconf git python3-dev python3-pip python3-venv python3-wheel nodejs npm && \

  17 | >>>     locale-gen en_US.UTF-8 && export LC_ALL=en_US.UTF-8 && \

  18 | >>>     npm config set registry https://registry.npmjs.org/ && \

  19 | >>>     npm install npm -g && \

  20 | >>>     echo "Running with nodejs:" && node -v && \

  21 | >>>     python3 -m venv /opt/venv && \

  22 | >>>     echo "Running with python:" && /opt/venv/bin/python3 -c 'import platform; print(platform.python_version())' && \

  23 | >>>     /opt/venv/bin/python3 -m pip install --no-cache-dir --upgrade pip setuptools wheel && \

  24 | >>>     /opt/venv/bin/python3 -m pip install --no-cache-dir -e . && \

  25 | >>>     npm install --unsafe-perm && \

  26 | >>>     node_modules/.bin/gulp --cwd /opt/lemur build && \

  27 | >>>     node_modules/.bin/gulp --cwd /opt/lemur package && \

  28 | >>>     npm cache clean --force && \

  29 | >>>     rm -rf node_modules && \

  30 | >>>     python3 -c 'print(" \033[32m BUILDER DONE \033[0m ")'

  31 |     

--------------------

failed to solve: process "/bin/sh -c apt-get update &&     apt-get -y --no-install-recommends upgrade &&     apt-get install -y --no-install-recommends libpq-dev curl build-essential locales libffi-dev libsasl2-dev libldap2-dev         dh-autoreconf git python3-dev python3-pip python3-venv python3-wheel nodejs npm &&     locale-gen en_US.UTF-8 && export LC_ALL=en_US.UTF-8 &&     npm config set registry https://registry.npmjs.org/ &&     npm install npm -g &&     echo \"Running with nodejs:\" && node -v &&     python3 -m venv /opt/venv &&     echo \"Running with python:\" && /opt/venv/bin/python3 -c 'import platform; print(platform.python_version())' &&     /opt/venv/bin/python3 -m pip install --no-cache-dir --upgrade pip setuptools wheel &&     /opt/venv/bin/python3 -m pip install --no-cache-dir -e . &&     npm install --unsafe-perm &&     node_modules/.bin/gulp --cwd /opt/lemur build &&     node_modules/.bin/gulp --cwd /opt/lemur package &&     npm cache clean --force &&     rm -rf node_modules &&     python3 -c 'print(\" \\033[32m BUILDER DONE \\033[0m \")'" did not complete successfully: exit code: 1

failed to start containers
```
This pull request updates the Docker build environment for Lemur to use Ubuntu 22.04 and modernizes the Node.js installation process. The main changes focus on updating the base image and improving package installation for better compatibility and security.

**Base image and dependency updates:**

* Updated both the builder and app stages in the `lemur-build-docker/Dockerfile` to use `ubuntu:22.04` instead of `ubuntu:20.04`, ensuring a more up-to-date and secure environment. [[1]](diffhunk://#diff-fdbf262700ced7ce11726911b6e8501abc9b95d9f741d229ef75ed8ad04db11dL2-R2) [[2]](diffhunk://#diff-fdbf262700ced7ce11726911b6e8501abc9b95d9f741d229ef75ed8ad04db11dL33-R38)

**Node.js installation improvements:**

* Switched to installing Node.js 20.x from the official NodeSource repository using signed packages, which enhances security and ensures the latest LTS version is used. This includes adding the NodeSource GPG key and repository and installing `nodejs` without `npm` as a separate package.

**Dependency cleanup:**

* Removed the installation of unnecessary packages such as `curl` and `npm` from the main dependency list, streamlining the build process.
